### PR TITLE
treat blank nodes as invalid triples

### DIFF
--- a/lib/rdfa-extractor.js
+++ b/lib/rdfa-extractor.js
@@ -17,9 +17,8 @@ export default class RDFAextractor {
 }
 
 async function convertNquadsToNtriples(nquadsData) {
-  const blankNodePrefix = "http://example.com/subject/";
   const store = new Store();
-  const parser = new Parser({ format: "N-Triples", blankNodePrefix });
+  const parser = new Parser({ format: "N-Triples" });
   const writer = new Writer({ format: "N-Triples" });
   const validTriples = [];
   const invalidTriples = [];
@@ -33,13 +32,9 @@ async function convertNquadsToNtriples(nquadsData) {
       if (quad) {
         const { subject, predicate, object } = quad;
         const triple = DataFactory.triple(
-          subject.value.includes("example.com")
-            ? namedNode(subject.value.replace("_:"))
-            : namedNode(subject.value),
-          namedNode(predicate.value.replace("@", "")),
-          object.value.includes("example.com")
-            ? namedNode(object.value.replace("_:"))
-            : object
+          subject,
+          predicate,
+          object
         );
         store.addQuad(quad);
         if (await validateTriple(triple)) {
@@ -61,6 +56,9 @@ async function convertNquadsToNtriples(nquadsData) {
       }
     });
   });
+  console.log("validTriples", validTriples.length)
+  console.log("invalidTriples", invalidTriples.length)
+
   return {
     validTriples: await convertTriplesToNtriples(validTriples),
     invalidTriples: await convertTriplesToNtriples(invalidTriples),


### PR DESCRIPTION
removed blank-node workaround.

This will result in two kinds of unnecessary/unwanted triples to be marked as invalid. These are byproducts of the jsonld structure.

```
:bn <https://data.lblod.info/ns/url> ?url.
:bn <https://data.lblod.info/ns/verenigingen> ?vereniging.
```