### PR TITLE
failsafe move and autocommit feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ This service will filter out <http://redpencil.data.gift/vocabularies/tasks/Task
 - **Example**: `http://virtuoso:8890/sparql`
 - **Default**: `http://virtuoso:8890/sparql`
 
+#### `FEATURE_ENABLE_MOVE_AUTOCOMMIT`
+
+- **Description**: Enables Virtuoso's autocommit mode with row-level logging (`sql:log-enable 3`) for the MOVE graph operation. This avoids transaction log size limits by performing row-level commits instead of a single atomic transaction. **Use with caution**: this makes the operation non-atomic, so ensure no parallel healing or import processes are running.
+- **Type**: Boolean
+- **Example**: `true`
+- **Default**: `false`
+
 ---
 
 ## Validation and correction

--- a/config.js
+++ b/config.js
@@ -35,3 +35,9 @@ export const ENDPOINT_REPLACE_SOURCE_GRAPH_OPERATION = envvar
   .example('http://virtuoso:8890/sparql')
   .default('http://virtuoso:8890/sparql')
   .asUrlString();
+
+export const FEATURE_ENABLE_MOVE_AUTOCOMMIT = envvar
+  .get('FEATURE_ENABLE_MOVE_AUTOCOMMIT')
+  .example('true')
+  .default('false')
+  .asBool();

--- a/lib/pipeline-import.js
+++ b/lib/pipeline-import.js
@@ -13,7 +13,8 @@ import {
   SIZE_IMPORT_BATCHES,
   ENDPOINT_IMPORT_BATCHES,
   IMPORT_TARGET_GRAPH,
-  ENDPOINT_REPLACE_SOURCE_GRAPH_OPERATION
+  ENDPOINT_REPLACE_SOURCE_GRAPH_OPERATION,
+  FEATURE_ENABLE_MOVE_AUTOCOMMIT
 } from '../config';
 
 import { storeToNTriples, batchedUpdate, storeAsArray, updateMutatiedienstStateInfo } from './utils';
@@ -65,10 +66,12 @@ export async function run(task) {
     const sourceGraph = IMPORT_TARGET_GRAPH;
 
     //Note: this is only tested in virtuoso
+    // 3: Autocommit mode with logging - i.e. row level commits - avoids transaction log size limit
+    // !! Non atomic - to be used with caution, need to ensure healing doesn't run in parallel !!
+    const logEnableDirective = FEATURE_ENABLE_MOVE_AUTOCOMMIT ? 'DEFINE sql:log-enable 3' : '';
     const queryStr = `
-      CLEAR GRAPH ${sparqlEscapeUri(sourceGraph)};
-      MOVE ${sparqlEscapeUri(tempImportGraph)} TO ${sparqlEscapeUri(sourceGraph)};
-      CLEAR GRAPH ${sparqlEscapeUri(tempImportGraph)}
+      ${logEnableDirective}
+      MOVE ${sparqlEscapeUri(tempImportGraph)} TO ${sparqlEscapeUri(sourceGraph)}
     `;
 
     const connectOptions = { sparqlEndpoint: ENDPOINT_REPLACE_SOURCE_GRAPH_OPERATION, mayRetry: true };


### PR DESCRIPTION
CLBV-1121

- Made move from temp graph to target safer
- feature flag to use virtuoso Row Autocommit Mode
  - avoids virtuoso SR325/40005 TransactionAfterImageLimit error 
  - default off, still need to prevent healing to run in parallel.
 

> The MOVE operation is a shortcut for moving all data from an input graph into a destination graph. The input graph is removed after insertion and data from the destination graph, if any, is removed before insertion.
https://www.w3.org/TR/sparql11-update/#move