### PR TITLE
bypass mu-auth for incremental updates

### DIFF
--- a/lib/pipeline-incremental-import.js
+++ b/lib/pipeline-incremental-import.js
@@ -197,76 +197,68 @@ function extractVerenigingTriples(verenigingSubject, validTriples) {
  */
 async function updateSourceGraph(sourceGraph, verenigingenSubject, updatedTriples) {
   const logEnableDirective = FEATURE_ENABLE_MOVE_AUTOCOMMIT ? 'DEFINE sql:log-enable 3' : '';
-  const queryStr = `
-    ${logEnableDirective}
-    DELETE {
-      GRAPH ${sparqlEscapeUri(sourceGraph)} {
-        ?vereniging ?vp ?vo.
-        ?id ?idp ?ido.
-        ?gi ?gip ?gio.
-        ?ta ?tap ?tao.
-        ?cp ?cpp ?cpo.
-        ?s ?sp ?so.
-        ?a ?ap ?ao.
-        ?m ?mp ?mo.
-        ?mper ?mperp ?mpero.
-        ?mpcp ?mpcpp ?mpcpo.
-      }
-    }
-    WHERE {
+  const connectionOptions = { sparqlEndpoint: ENDPOINT_IMPORT_BATCHES, mayRetry: true };
+
+  // Step 1: Collect all subject URIs related to this vereniging (read-only, no lock escalation)
+  const selectQuery = `
+    SELECT DISTINCT ?s WHERE {
       VALUES ?vereniging {
         ${rst.termToString(verenigingenSubject)}
       }
       GRAPH ${sparqlEscapeUri(sourceGraph)} {
-        {
-          ?vereniging ?vp ?vo.
-        }
+        { BIND(?vereniging AS ?s) }
+        UNION { ?vereniging <http://www.w3.org/ns/adms#identifier> ?s }
         UNION {
           ?vereniging <http://www.w3.org/ns/adms#identifier> ?id.
-          ?id ?idp ?ido.
+          ?id <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?s.
         }
+        UNION { ?vereniging <http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/doelgroep> ?s }
+        UNION { ?vereniging <http://schema.org/contactPoint> ?s }
+        UNION { ?vereniging <http://www.w3.org/ns/org#hasSite>|<http://www.w3.org/ns/org#hasPrimarySite> ?s }
         UNION {
-          ?vereniging <http://www.w3.org/ns/adms#identifier> ?id.
-          ?id <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?gi.
-          ?gi ?gip ?gio.
+          ?vereniging <http://www.w3.org/ns/org#hasSite>|<http://www.w3.org/ns/org#hasPrimarySite> ?site.
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?s.
         }
-        UNION {
-          ?vereniging <http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/doelgroep> ?ta.
-          ?ta ?tap ?tao.
-        }
-        UNION {
-          ?vereniging <http://schema.org/contactPoint> ?cp.
-          ?cp ?cpp ?cpo.
-        }
-        UNION {
-          ?vereniging <http://www.w3.org/ns/org#hasSite>|<http://www.w3.org/ns/org#hasPrimarySite> ?s.
-          ?s ?sp ?so.
-        }
-        UNION {
-          ?vereniging <http://www.w3.org/ns/org#hasSite>|<http://www.w3.org/ns/org#hasPrimarySite> ?s.
-          ?s <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?a.
-          ?a ?ap ?ao.
-        }
+        UNION { ?vereniging <http://www.w3.org/ns/org#hasMembership> ?s }
         UNION {
           ?vereniging <http://www.w3.org/ns/org#hasMembership> ?m.
-          ?m ?mp ?mo.
-        }
-        UNION {
-          ?vereniging <http://www.w3.org/ns/org#hasMembership> ?m.
-          ?m <http://www.w3.org/ns/org#member> ?mper.
-          ?mper ?mperp ?mpero.
+          ?m <http://www.w3.org/ns/org#member> ?s.
         }
         UNION {
           ?vereniging <http://www.w3.org/ns/org#hasMembership> ?m.
           ?m <http://www.w3.org/ns/org#member> ?mp.
-          ?mp <http://schema.org/contactPoint> ?mpcp.
-          ?mpcp ?mpcpp ?mpcpo.
+          ?mp <http://schema.org/contactPoint> ?s.
         }
       }
     }
+  `;
 
-    ;
+  const result = await query(selectQuery, {}, connectionOptions);
+  const subjects = result.results.bindings.map(b => `<${b.s.value}>`);
 
+  if (subjects.length) {
+    // Step 2: Delete all triples for the collected subjects (simple flat query)
+    const deleteQuery = `
+      ${logEnableDirective}
+      DELETE {
+        GRAPH ${sparqlEscapeUri(sourceGraph)} {
+          ?s ?p ?o.
+        }
+      }
+      WHERE {
+        VALUES ?s { ${subjects.join(' ')} }
+        GRAPH ${sparqlEscapeUri(sourceGraph)} {
+          ?s ?p ?o.
+        }
+      }
+    `;
+
+    await update(deleteQuery, {}, connectionOptions);
+  }
+
+  // Step 3: Insert the new data
+  const insertQuery = `
+    ${logEnableDirective}
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(sourceGraph)} {
         ${updatedTriples.join('\n')}
@@ -274,5 +266,5 @@ async function updateSourceGraph(sourceGraph, verenigingenSubject, updatedTriple
     }
   `;
 
-  await update(queryStr, {}, { sparqlEndpoint: ENDPOINT_IMPORT_BATCHES, mayRetry: true });
+  await update(insertQuery, {}, connectionOptions);
 }

--- a/lib/pipeline-incremental-import.js
+++ b/lib/pipeline-incremental-import.js
@@ -12,7 +12,8 @@ import {
 
 import {
   IMPORT_TARGET_GRAPH,
-  SIZE_IMPORT_BATCHES_INCREMENTAL
+  SIZE_IMPORT_BATCHES_INCREMENTAL,
+  ENDPOINT_IMPORT_BATCHES
 } from '../config';
 
 import { storeToNTriples, storeAsArray, updateMutatiedienstStateInfo } from './utils';
@@ -268,5 +269,5 @@ async function updateSourceGraph(sourceGraph, verenigingenSubject, updatedTriple
     }
   `;
 
-  await update(queryStr);
+  await update(queryStr, {}, { sparqlEndpoint: ENDPOINT_IMPORT_BATCHES, mayRetry: true });
 }

--- a/lib/pipeline-incremental-import.js
+++ b/lib/pipeline-incremental-import.js
@@ -3,7 +3,7 @@ import { v5 as uuidv5 } from "uuid";
 import * as N3 from 'n3';
 import * as rst from 'rdf-string-ttl';
 const { namedNode, literal } = N3.DataFactory;
-import { updateSudo as update } from "@lblod/mu-auth-sudo";
+import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 import {
   STATUS_BUSY,
   STATUS_SUCCESS,

--- a/lib/pipeline-incremental-import.js
+++ b/lib/pipeline-incremental-import.js
@@ -13,7 +13,9 @@ import {
 import {
   IMPORT_TARGET_GRAPH,
   SIZE_IMPORT_BATCHES_INCREMENTAL,
-  ENDPOINT_IMPORT_BATCHES
+  ENDPOINT_IMPORT_BATCHES,
+  FEATURE_ENABLE_MOVE_AUTOCOMMIT,
+  SLEEP_BETWEEN_IMPORT_BATCHES
 } from '../config';
 
 import { storeToNTriples, storeAsArray, updateMutatiedienstStateInfo } from './utils';
@@ -63,6 +65,7 @@ export async function run(task) {
           const verenigingStore = extractVerenigingTriples(verenigingSubject, validTriples);
           await updateSourceGraph(IMPORT_TARGET_GRAPH, verenigingSubject, storeAsArray(verenigingStore));
         }));
+      await new Promise(r => setTimeout(r, SLEEP_BETWEEN_IMPORT_BATCHES));
     }
 
     // Note: for debugging purposes; we'll keep this information and link it to the task
@@ -193,7 +196,9 @@ function extractVerenigingTriples(verenigingSubject, validTriples) {
  *   in the non-incremental job
  */
 async function updateSourceGraph(sourceGraph, verenigingenSubject, updatedTriples) {
+  const logEnableDirective = FEATURE_ENABLE_MOVE_AUTOCOMMIT ? 'DEFINE sql:log-enable 3' : '';
   const queryStr = `
+    ${logEnableDirective}
     DELETE {
       GRAPH ${sparqlEscapeUri(sourceGraph)} {
         ?vereniging ?vp ?vo.


### PR DESCRIPTION
CLBV-1178

Some incremental updates choke mu-auth and cause it to hangup.

Picking up after a failed job takes hours due to the many sequential updates - this should speed it up.

Consider switching to sparql-parser later if the harvester stack is kept.